### PR TITLE
chore: Disable ctf push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,13 +105,13 @@ jobs:
         with:
           tag_name: ${{ env.version }}
           name: Release ${{ env.version }}
-          body: RELEASE_BODY.md
+          body_path: RELEASE_BODY.md
           draft: true
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Push CTF
-        if: ${{ env.SKIP != 'true' }}
-        run: |
-          ocm transfer ctf --overwrite ./openmcp-ctf/ ${{ env.OCI_URL }} 
+      # - name: Push CTF
+      #   if: ${{ env.SKIP != 'true' }}
+      #   run: |
+      #     ocm transfer ctf --overwrite ./openmcp-ctf/ ${{ env.OCI_URL }} 

--- a/component-constructor.yaml
+++ b/component-constructor.yaml
@@ -31,7 +31,6 @@ components:
           commit: "${OPENMCP_VERSION}"
           type: gitHub
           repoUrl: https://github.com/openmcp-project/openmcp
-          ref: refs/heads/main
         name: openmcp
         type: git
         version: ${OPENMCP_VERSION}
@@ -58,7 +57,6 @@ components:
           commit: ${MCP_OPERATOR_VERSION}
           type: gitHub
           repoUrl: https://github.com/openmcp-project/mcp-operator
-          ref: refs/heads/main
         name: openmcp
         type: git
         version: ${MCP_OPERATOR_VERSION}
@@ -79,7 +77,6 @@ components:
           commit: ${OPENMCP_OPERATOR_VERSION}
           type: gitHub
           repoUrl: https://github.com/openmcp-project/openmcp-operator
-          ref: refs/heads/main
         name: openmcp
         type: git
         version: ${OPENMCP_OPERATOR_VERSION}
@@ -106,7 +103,6 @@ components:
           commit: ${CONTROL_PLANE_OPERATOR_VERSION}
           type: gitHub
           repoUrl: https://github.com/openmcp-project/control-plane-operator
-          ref: refs/heads/main
         name: openmcp
         type: git
         version: ${CONTROL_PLANE_OPERATOR_VERSION}
@@ -133,7 +129,6 @@ components:
           commit: ${QUOTA_OPERATOR_VERSION}
           type: gitHub
           repoUrl: https://github.com/openmcp-project/quota-operator
-          ref: refs/heads/main
         name: openmcp
         type: git
         version: ${QUOTA_OPERATOR_VERSION}
@@ -161,7 +156,6 @@ components:
           commit: ${PROJECT_WORKSPACE_OPERATOR_VERSION}
           type: gitHub
           repoUrl: https://github.com/openmcp-project/project-workspace-operator
-          ref: refs/heads/main
         name: openmcp
         type: git
         version: ${PROJECT_WORKSPACE_OPERATOR_VERSION}


### PR DESCRIPTION
Release MCP Landscape v0.0.1 featuring currently the current OpenMCP Project open-sourced components. The Release is published as an OCM componentversion referencing all the systems components.