### PR TITLE
fix: creation of the release body

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,29 +84,12 @@ jobs:
           ocm add componentversions --create \
           --file openmcp-ctf component-constructor.yaml \
           --settings components-versions.yaml  -- OPENMCP_VERSION=${{ env.version }} OPENMCP_VERSION_COMMIT=$(git show-ref --hash ${{ env.version }})
-      
-      - name: Get PR body for current commit
-        id: release_highlights 
-        if: ${{ env.SKIP != 'true' }}
-        
-        run: |
-          COMMIT_SHA=$(git rev-parse HEAD)
-          PR_NUMBER=$(gh pr list --search "$COMMIT_SHA" --state merged --json number --jq '.[0].number')
-          if [ -z "$PR_NUMBER" ]; then
-            echo "No PR found for commit $COMMIT_SHA, skipping."
-            echo "pr_body=" >> "$GITHUB_ENV"
-            exit 0
-          fi
-          echo "pr_body=\"$(gh pr view "$PR_NUMBER" --json body --jq .body)\"" >> "$GITHUB_ENV"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
           
       - name: Build Changelog
         if: ${{ env.SKIP != 'true' }}
         id: constructed_release
         run: |
           cat hack/release-body.tpl > RELEASE_BODY.md
-          echo "${{ env.pr_body }}" >> RELEASE_BODY.md
           echo -e "## Components:\n" >> RELEASE_BODY.md
           ./hack/generate_release_notes.sh openmcp-ctf >> RELEASE_BODY.md
         env:

--- a/hack/release-body.tpl
+++ b/hack/release-body.tpl
@@ -1,3 +1,1 @@
-# MCP Landscape
-
-## Highlights
+# openMCP


### PR DESCRIPTION
**What this PR does / why we need it**:

Putting the content of the release PR into a environment variable doesn't work when the PR is multiline.
Therefore the creation of the release fails with the current pull request template.

Since this repository contains only references to its sub-somponents anyway, it doesn't need to include the pull request content for the release anyway because it doesn't contain any meaningful value.

Therefore the parsing of the pr body of the release pull request and adding it to the release will be removed via this PR.

**Which issue(s) this PR fixes**:

https://github.com/openmcp-project/openmcp/actions/runs/16137380330/job/45537137514

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix creation of the release body
```
