### PR TITLE
fix: wrong name for component service-provider-gardener

### DIFF
--- a/component-constructor.yaml
+++ b/component-constructor.yaml
@@ -34,7 +34,7 @@ components:
         version: ${SERVICE_PROVIDER_LANDSCAPER_VERSION}
 
       - componentName: github.com/openmcp-project/cluster-provider-gardener
-        name: cluster-provider-landscaper
+        name: cluster-provider-gardener
         version: ${CLUSTER_PROVIDER_GARDENER_VERSION}
     sources:
       - access:


### PR DESCRIPTION
**What this PR does / why we need it**:

The wrong name for the cluster-provider-gardener was used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix other
Fix component name for cluster-provider-gardener
```
