### PR TITLE
feat: add fluxcd controller images to openmcp component

### DIFF
--- a/component-constructor.yaml
+++ b/component-constructor.yaml
@@ -74,6 +74,30 @@ components:
           path: ghcr.io/fluxcd/helm-controller:${FLUXCD_HELM_CONTROLLER_VERSION}
           repository: images/fluxcd/helm-controller
 
+      - name: fluxcd-notification-controller
+        version: ${FLUXCD_NOTIFICATION_CONTROLLER_VERSION}
+        type: ociImage
+        input:
+          type: ociImage
+          path: ghcr.io/fluxcd/notification-controller:${FLUXCD_NOTIFICATION_CONTROLLER_VERSION}
+          repository: images/fluxcd/notification-controller
+
+      - name: fluxcd-image-reflector-controller
+        version: ${FLUXCD_IMAGE_REFLECTOR_CONTROLLER_VERSION}
+        type: ociImage
+        input:
+          type: ociImage
+          path: ghcr.io/fluxcd/image-reflector-controller:${FLUXCD_IMAGE_REFLECTOR_CONTROLLER_VERSION}
+          repository: images/fluxcd/image-reflector-controller
+
+      - name: fluxcd-image-automation-controller
+        version: ${FLUXCD_IMAGE_AUTOMATION_CONTROLLER_VERSION}
+        type: ociImage
+        input:
+          type: ociImage
+          path: ghcr.io/fluxcd/image-automation-controller:${FLUXCD_IMAGE_AUTOMATION_CONTROLLER_VERSION}
+          repository: images/fluxcd/image-automation-controller
+
     sources:
       - access:
           ref: "refs/tags/${OPENMCP_VERSION}"

--- a/components-versions.yaml
+++ b/components-versions.yaml
@@ -31,3 +31,9 @@ FLUXCD_SOURCE_CONTROLLER_VERSION: "v1.6.2"
 FLUXCD_KUSTOMIZE_CONTROLLER_VERSION: "v1.6.1"
 # renovate: datasource=github-releases depName=fluxcd/helm-controller
 FLUXCD_HELM_CONTROLLER_VERSION: "v1.3.0"
+# renovate: datasource=github-releases depName=fluxcd/notification-controller
+FLUXCD_NOTIFICATION_CONTROLLER_VERSION: "v1.6.0"
+# renovate: datasource=github-releases depName=fluxcd/image-reflector-controller
+FLUXCD_IMAGE_REFLECTOR_CONTROLLER_VERSION: "v0.35.2"
+# renovate: datasource=github-releases depName=fluxcd/image-automation-controller
+FLUXCD_IMAGE_AUTOMATION_CONTROLLER_VERSION: "v0.41.2"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the oci images of the fluxcd/notification-controller, fluxcd/image-reflector-controller, and fluxcd/image-automation-controller to the openmcp component.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Additional OCI images as resources of the openmcp component: fluxcd/notification-controller, fluxcd/image-reflector-controller, and fluxcd/image-automation-controller.

```
