### PR TITLE
refactor: rename project-workspace-operator to platform-service-project-workspace

### DIFF
--- a/component-constructor.yaml
+++ b/component-constructor.yaml
@@ -29,9 +29,9 @@ components:
         name: quota-operator
         version: ${QUOTA_OPERATOR_VERSION}
 
-      - componentName: github.com/openmcp-project/project-workspace-operator
-        name: project-workspace-operator
-        version: ${PROJECT_WORKSPACE_OPERATOR_VERSION}
+      - componentName: github.com/openmcp-project/platform-service-project-workspace
+        name: platform-service-project-workspace
+        version: ${PLATFORM_SERVICE_PROJECT_WORKSPACE_VERSION}
 
       - componentName: github.com/openmcp-project/bootstrapper
         name: bootstrapper
@@ -87,7 +87,7 @@ components:
         name: platform-service-test-runner
         version: ${PLATFORM_SERVICE_TEST_RUNNER}
 
-      - componentName: github.com/openmcp-project/project-workspace-operator
+      - componentName: github.com/openmcp-project/platform-service-project-workspace
         name: platform-service-project-workspace
         version: ${PLATFORM_SERVICE_PROJECT_WORKSPACE_VERSION}
 

--- a/components-versions.yaml
+++ b/components-versions.yaml
@@ -2,8 +2,6 @@
 CONTROL_PLANE_OPERATOR_VERSION: "v0.1.19"
 # renovate: datasource=github-releases depName=openmcp-project/quota-operator
 QUOTA_OPERATOR_VERSION: "v0.18.0"
-# renovate: datasource=github-releases depName=openmcp-project/project-workspace-operator
-PROJECT_WORKSPACE_OPERATOR_VERSION: "v1.4.0"
 # renovate: datasource=github-releases depName=openmcp-project/mcp-operator
 MCP_OPERATOR_VERSION: "v0.54.0"
 # renovate: datasource=github-releases depName=openmcp-project/openmcp-operator
@@ -36,8 +34,8 @@ PLATFORM_SERVICE_DNS_VERSION: "v0.0.5"
 PLATFORM_SERVICE_GATEWAY_VERSION: "v0.0.10"
 # renovate: datasource=github-releases depName=openmcp-project/platform-service-test-runner
 PLATFORM_SERVICE_TEST_RUNNER: "v0.0.1"
-# renovate: datasource=github-releases depName=openmcp-project/project-workspace-operator
-PLATFORM_SERVICE_PROJECT_WORKSPACE_VERSION: "v1.4.0"
+# renovate: datasource=github-releases depName=openmcp-project/platform-service-project-workspace
+PLATFORM_SERVICE_PROJECT_WORKSPACE_VERSION: "v2.0.0"
 # renovate: datasource=github-releases depName=openmcp-project/usage-operator
 PLATFORM_SERVICE_USAGE_VERSION: "v0.0.16"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Follow-up of https://github.com/openmcp-project/platform-service-project-workspace/pull/214

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Upgraded the `project-workspace-operator` to `v2.0.0`, which includes its renaming to `platform-service-project-workspace`.
```
