### PR TITLE
fix: dependencies not recognized by renovate

### DIFF
--- a/component-constructor.yaml
+++ b/component-constructor.yaml
@@ -89,7 +89,7 @@ components:
 
       - componentName: github.com/openmcp-project/platform-service-test-runner
         name: platform-service-test-runner
-        version: ${PLATFORM_SERVICE_TEST_RUNNER}
+        version: ${PLATFORM_SERVICE_TEST_RUNNER_VERSION}
 
       - componentName: github.com/openmcp-project/platform-service-project-workspace
         name: platform-service-project-workspace

--- a/components-versions.yaml
+++ b/components-versions.yaml
@@ -37,7 +37,7 @@ PLATFORM_SERVICE_GATEWAY_VERSION: "v0.0.13"
 # renovate: datasource=github-releases depName=openmcp-project/platform-service-quota
 PLATFORM_SERVICE_QUOTA_VERSION: "v1.0.2"
 # renovate: datasource=github-releases depName=openmcp-project/platform-service-test-runner
-PLATFORM_SERVICE_TEST_RUNNER: "v1.0.1"
+PLATFORM_SERVICE_TEST_RUNNER_VERSION: "v1.0.1"
 # renovate: datasource=github-releases depName=openmcp-project/platform-service-project-workspace
 PLATFORM_SERVICE_PROJECT_WORKSPACE_VERSION: "v2.1.2"
 # renovate: datasource=github-releases depName=openmcp-project/usage-operator
@@ -60,7 +60,7 @@ GITOPS_TEMPLATES_VERSION: "v0.1.5"
 
 # renovate: datasource=github-releases depName=kubernetes-sigs/external-dns
 EXTERNAL_DNS_IMAGE_VERSION: "v0.21.0"
-# renovate: datasource=helm registryUrl=https://kubernetes-sigs.github.io/external-dns depName=external-dns
+# renovate: datasource=helm depName=external-dns registryUrl=https://kubernetes-sigs.github.io/external-dns
 EXTERNAL_DNS_CHART_VERSION: "1.21.0"
 
 # renovate: datasource=github-releases depName=fluxcd/source-controller


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes two dependencies not being recognized by renovate due to the renovate regex not matching the corresponding lines:
- The renovate regex expects a `_VERSION` suffix, which was missing for the test runner.
- The renovate regex expects `depName` to come before `registryUrl`, which was the other way around for the external-dns helm chart.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
