### PR TITLE
feat: add reference to new usage operator component

### DIFF
--- a/component-constructor.yaml
+++ b/component-constructor.yaml
@@ -99,6 +99,10 @@ components:
         name: platform-service-usage
         version: ${PLATFORM_SERVICE_USAGE_VERSION}
 
+      - componentName: github.com/openmcp-project/usage-operator
+        name: platform-service-usagev2
+        version: ${PLATFORM_SERVICE_USAGE_V2_VERSION}
+
       # observability-stack
       - componentName: github.com/openmcp-project/observability-stack
         name: observability-stack

--- a/components-versions.yaml
+++ b/components-versions.yaml
@@ -40,8 +40,12 @@ PLATFORM_SERVICE_QUOTA_VERSION: "v1.1.0"
 PLATFORM_SERVICE_TEST_RUNNER_VERSION: "v1.1.0"
 # renovate: datasource=github-releases depName=openmcp-project/platform-service-project-workspace
 PLATFORM_SERVICE_PROJECT_WORKSPACE_VERSION: "v2.3.0"
-# renovate: datasource=github-releases depName=openmcp-project/usage-operator
+
+# Old usage operator. Version v0.1.0 is fix. Do not change it.
 PLATFORM_SERVICE_USAGE_VERSION: "v0.1.0"
+# New usage operator
+# renovate: datasource=github-releases depName=openmcp-project/usage-operator
+PLATFORM_SERVICE_USAGE_V2_VERSION: "v1.0.0"
 
 # observability-stack
 # renovate: datasource=github-releases depName=openmcp-project/observability-stack


### PR DESCRIPTION
On-behalf-of: @SAP robert.graeff@sap.com

**What this PR does / why we need it**:

This PR adds a component reference to the new usage operator. 

The component reference to the old usage operator is not removed, because for a test phase we want to run both in parallel: the old usage operator still productively, and the new usage operator on a trial basis. This is possible as both operate on different  resources.

This means we will have two component references to different versions of component [github.com/openmcp-project/usage-operator](https://github.com/orgs/openmcp-project/packages/container/package/components%2Fcomponent-descriptors%2Fgithub.com%2Fopenmcp-project%2Fusage-operator):
- component reference `platform-service-usage` points to the old component version `v0.1.0`,
- component reference `platform-service-usagev2` points to the new component version, probably `v1.0.0`.

#### Bootstrapping

The names of the component references are relevant during the bootstrapping. The following bootstrapper config results in two PlatformServices:

```yaml
providers:
  platformServices:
  - name: usage
  - name: usagev2
```

Their images are taken from component versions search by the component reference name `platform-service-...`, here `platform-service-usage` and `platform-service-usagev2`. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
- Add new usage operator component
```
